### PR TITLE
Update SQLite and core extension

### DIFF
--- a/.changeset/evil-planets-add.md
+++ b/.changeset/evil-planets-add.md
@@ -1,0 +1,5 @@
+---
+"@powersync/sql-js": minor
+---
+
+Update SQLite to 3.50.4, PowerSync extension to 0.4.4

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 set -e
 
-SQLITE_VERSION="2.7.6"
-POWERSYNC_CORE_VERSION="0.4.2"
+POWERSYNC_CORE_VERSION="0.4.4"
 SQLITE_PATH="sql.js"
 
 if [ -d "$SQLITE_PATH" ]; then

--- a/patches/powersync.patch
+++ b/patches/powersync.patch
@@ -1,17 +1,27 @@
 diff --git a/Makefile b/Makefile
-index 4530653..5ac01a0 100644
+index 4530653..8c40a26 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -14,6 +14,8 @@ SQLITE_AMALGAMATION_ZIP_SHA3 = e7eb4cfb2d95626e782cfa748f534c74482f2c3c93f13ee82
+@@ -6,14 +6,15 @@
+ 
+ # I got this handy makefile syntax from : https://github.com/mandel59/sqlite-wasm (MIT License) Credited in LICENSE
+ # To use another version of Sqlite, visit https://www.sqlite.org/download.html and copy the appropriate values here:
+-SQLITE_AMALGAMATION = sqlite-amalgamation-3490100
+-SQLITE_AMALGAMATION_ZIP_URL = https://sqlite.org/2025/sqlite-amalgamation-3490100.zip
+-SQLITE_AMALGAMATION_ZIP_SHA3 = e7eb4cfb2d95626e782cfa748f534c74482f2c3c93f13ee828b9187ce05b2da7
++SQLITE_AMALGAMATION = sqlite-amalgamation-3500400
++SQLITE_AMALGAMATION_ZIP_URL = https://sqlite.org/2025/sqlite-amalgamation-3500400.zip
++SQLITE_AMALGAMATION_ZIP_SHA256 = 1d3049dd0f830a025a53105fc79fd2ab9431aea99e137809d064d8ee8356b032
+ 
+ # Note that extension-functions.c hasn't been updated since 2010-02-06, so likely doesn't need to be updated
  EXTENSION_FUNCTIONS = extension-functions.c
  EXTENSION_FUNCTIONS_URL = https://www.sqlite.org/contrib/download/extension-functions.c?get=25
  EXTENSION_FUNCTIONS_SHA1 = c68fa706d6d9ff98608044c00212473f9c14892f
 +POWERSYNC_STATIC_FILES = powersync-libs/libpowersync-wasm.a
-+
  
  EMCC=emcc
  
-@@ -24,7 +26,8 @@ SQLITE_COMPILATION_FLAGS = \
+@@ -24,7 +25,8 @@ SQLITE_COMPILATION_FLAGS = \
  	-DSQLITE_ENABLE_FTS3 \
  	-DSQLITE_ENABLE_FTS3_PARENTHESIS \
  	-DSQLITE_THREADSAFE=0 \
@@ -21,7 +31,7 @@ index 4530653..5ac01a0 100644
  
  # When compiling to WASM, enabling memory-growth is not expected to make much of an impact, so we enable it for all builds
  # Since tihs is a library and not a standalone executable, we don't want to catch unhandled Node process exceptions
-@@ -59,7 +62,7 @@ EMFLAGS_DEBUG = \
+@@ -59,7 +61,7 @@ EMFLAGS_DEBUG = \
  	-s ASSERTIONS=2 \
  	-O1
  
@@ -30,7 +40,7 @@ index 4530653..5ac01a0 100644
  
  OUTPUT_WRAPPER_FILES = src/shell-pre.js src/shell-post.js
  
-@@ -76,13 +79,13 @@ all: optimized debug worker
+@@ -76,13 +78,13 @@ all: optimized debug worker
  debug: dist/sql-asm-debug.js dist/sql-wasm-debug.js
  
  dist/sql-asm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
@@ -46,7 +56,7 @@ index 4530653..5ac01a0 100644
  	mv $@ out/tmp-raw.js
  	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
  	rm out/tmp-raw.js
-@@ -91,19 +94,19 @@ dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FI
+@@ -91,19 +93,19 @@ dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FI
  optimized: dist/sql-asm.js dist/sql-wasm.js dist/sql-asm-memory-growth.js
  
  dist/sql-asm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
@@ -69,7 +79,7 @@ index 4530653..5ac01a0 100644
  	mv $@ out/tmp-raw.js
  	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
  	rm out/tmp-raw.js
-@@ -153,6 +156,9 @@ out/extension-functions.o: sqlite-src/$(SQLITE_AMALGAMATION)
+@@ -153,6 +155,9 @@ out/extension-functions.o: sqlite-src/$(SQLITE_AMALGAMATION)
  	# Generate llvm bitcode
  	$(EMCC) $(SQLITE_COMPILATION_FLAGS) -c sqlite-src/$(SQLITE_AMALGAMATION)/extension-functions.c -o $@
  
@@ -79,7 +89,18 @@ index 4530653..5ac01a0 100644
  # TODO: This target appears to be unused. If we re-instatate it, we'll need to add more files inside of the JS folder
  # module.tar.gz: test package.json AUTHORS README.md dist/sql-asm.js
  # 	tar --create --gzip $^ > $@
-@@ -182,11 +188,15 @@ sqlite-src/$(SQLITE_AMALGAMATION): cache/$(SQLITE_AMALGAMATION).zip sqlite-src/$
+@@ -172,8 +177,8 @@ sqlite-src: sqlite-src/$(SQLITE_AMALGAMATION) sqlite-src/$(SQLITE_AMALGAMATION)/
+ 
+ sqlite-src/$(SQLITE_AMALGAMATION): cache/$(SQLITE_AMALGAMATION).zip sqlite-src/$(SQLITE_AMALGAMATION)/$(EXTENSION_FUNCTIONS)
+ 	mkdir -p sqlite-src/$(SQLITE_AMALGAMATION)
+-	echo '$(SQLITE_AMALGAMATION_ZIP_SHA3)  ./cache/$(SQLITE_AMALGAMATION).zip' > cache/check.txt
+-	sha3sum -a 256 -c cache/check.txt
++	echo '$(SQLITE_AMALGAMATION_ZIP_SHA256)  ./cache/$(SQLITE_AMALGAMATION).zip' > cache/check.txt
++	sha256sum -c cache/check.txt
+ 	# We don't delete the sqlite_amalgamation folder. That's a job for clean
+ 	# Also, the extension functions get copied here, and if we get the order of these steps wrong,
+ 	# this step could remove the extension functions, and that's not what we want
+@@ -182,11 +187,15 @@ sqlite-src/$(SQLITE_AMALGAMATION): cache/$(SQLITE_AMALGAMATION).zip sqlite-src/$
  
  sqlite-src/$(SQLITE_AMALGAMATION)/$(EXTENSION_FUNCTIONS): cache/$(EXTENSION_FUNCTIONS)
  	mkdir -p sqlite-src/$(SQLITE_AMALGAMATION)


### PR DESCRIPTION
This updates the core extension to 0.4.4. I've also patched the makefile to:

- Use the latest SQLite version, 3.50.4
- Updated the checksum for the SQLite download to use `sha256sum` instead of `sha3sum` (that command doesn't seem to be available on my machine...).