### PR TITLE
Make pending release a patch release

### DIFF
--- a/.changeset/evil-planets-add.md
+++ b/.changeset/evil-planets-add.md
@@ -1,5 +1,5 @@
 ---
-"@powersync/sql-js": minor
+"@powersync/sql-js": patch
 ---
 
 Update SQLite to 3.50.4, PowerSync extension to 0.4.4


### PR DESCRIPTION
https://github.com/powersync-ja/powersync-sql-js/pull/7 introduced a `minor` changeset entry that should have been a patch release (updating the package to 0.0.3 instead of 0.1.0). To prepare the release, this downgrades the scope to be a patch release.