### PR TITLE
Update PowerSync core to v0.4.10

### DIFF
--- a/.changeset/eighty-geckos-occur.md
+++ b/.changeset/eighty-geckos-occur.md
@@ -1,0 +1,5 @@
+---
+'@powersync/sql-js': minor
+---
+
+Update PowerSync core to v0.4.10

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-POWERSYNC_CORE_VERSION="0.4.8"
+POWERSYNC_CORE_VERSION="0.4.10"
 SQLITE_PATH="sql.js"
 
 if [ -d "$SQLITE_PATH" ]; then


### PR DESCRIPTION
Updates the PowerSync core from https://github.com/powersync-ja/powersync-sqlite-core/releases/tag/v0.4.10