### PR TITLE
Update core extension to 0.5.2

### DIFF
--- a/.changeset/odd-carrots-fix.md
+++ b/.changeset/odd-carrots-fix.md
@@ -1,0 +1,5 @@
+---
+"@powersync/sql-js": patch
+---
+
+Update PowerSync SQLite core extension to version 0.5.2.

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-POWERSYNC_CORE_VERSION="0.5.1"
+POWERSYNC_CORE_VERSION="0.5.2"
 SQLITE_PATH="sql.js"
 
 if [ -d "$SQLITE_PATH" ]; then


### PR DESCRIPTION
This updates the core extension to 0.5.2, fixing an issue with read-only connections (that doesn't affect this package as it doesn't support connection pools, but we want to keep the version consistent across differnet JS SDKs).